### PR TITLE
Replace <b> tags with <strongs>

### DIFF
--- a/src/Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/src/Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -47,10 +47,10 @@
                         Note that for demo purposes you don't need to register and can login with these credentials:
                     </p>
                     <p>
-                        User:     <b>demouser@microsoft.com</b>
+                        User:     <strong>demouser@microsoft.com</strong>
                     </p>
                     <p>
-                        Password: <b>Pass@word1</b>
+                        Password: <strong>Pass@word1</strong>
                     </p>
                 </form>
             </section>


### PR DESCRIPTION
Per SonarQube recommendation, we should use \<strong\> tags instead of \<b\>
to supply the semantic meaning.

Fixes rule: Web:BoldAndItalicTagsCheck